### PR TITLE
 charts/sauce-connect: use ConfigMap for sc configuration

### DIFF
--- a/charts/sauce-connect/templates/configmap.yaml
+++ b/charts/sauce-connect/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sauce-connect.fullname" . }}
+  labels:
+    {{- include "sauce-connect.labels" . | nindent 4 }}
+data:
+  sauce-connect.yaml: |
+  {{- $config := omit .Values.config "enabled" }}
+  {{- toYaml $config | default "{}" | nindent 4  }}
+  {{- range $key, $value := .Values.templates }}
+  {{ $key }}: |-
+    {{- $value | nindent 4 }}
+  {{- end }}

--- a/charts/sauce-connect/templates/deployment.yaml
+++ b/charts/sauce-connect/templates/deployment.yaml
@@ -34,21 +34,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
-            - name: SAUCE_REGION
-              value: {{ .Values.sc.region | quote }}
-            - name: SAUCE_USERNAME
-              value: {{ .Values.sc.user | quote }}
-            - name: SAUCE_ACCESS_KEY
-              value: {{ .Values.sc.accessKey | quote }}
-            - name: SAUCE_API_ADDRESS
-              value: "0.0.0.0:{{ .Values.api.port }}"
-            - name: SAUCE_TUNNEL_NAME
-              value: {{ .Values.sc.tunnelName | quote }}
-            - name: SAUCE_TUNNEL_POOL
-              value: {{ .Values.tunnelPool | quote }}
-            - name: SAUCE_LOG_LEVEL
-              value: {{ .Values.sc.logLevel | quote }}
+            - name: SAUCE_CONFIG_FILE
+              value: /etc/config/sauce-connect.yaml
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
           ports:
             - name: api
               containerPort: {{ .Values.api.port }}
@@ -68,6 +59,10 @@ spec:
             periodSeconds: 1
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "sauce-connect.fullname" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/sauce-connect/templates/deployment.yaml
+++ b/charts/sauce-connect/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
           env:
             - name: SAUCE_CONFIG_FILE
               value: /etc/config/sauce-connect.yaml
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: config-volume

--- a/charts/sauce-connect/values.yaml
+++ b/charts/sauce-connect/values.yaml
@@ -51,20 +51,18 @@ tolerations: []
 affinity: {}
 
 # Sauce Connect Proxy Configuration
-sc:
+# See https://docs.saucelabs.com/dev/cli/sauce-connect-5/run for more options
+config:
   region: "us-west"
-  # user must be defined
-  user: ""
+  # username must be defined
+  username: ""
   # accessKey must be defined
-  accessKey: ""
-  # It's recommended to define your own tunnelName
-  tunnelName: "sc-k8s-tunnel"
-  tunnelPool: "true"
-  logLevel: "info"
-# It's recommended to define your own tunnelName
-tunnelName: "sc-k8s-tunnel"
-tunnelPool: "true"
-scLogLevel: "info"
+  access-key: ""
+  # tunnel-name must be defined
+  tunnel-name: "sc-k8s-tunnel"
+  tunnel-pool: "true"
+  # enable api server, needed for k8s readiness/liveness probes
+  api-address: :8032
 
 # See https://docs.saucelabs.com/secure-connections/sauce-connect/proxy-tunnels/#configuring-status-server
 api:


### PR DESCRIPTION
Without this patch we are limited to a few hand-picked config option.

To solve that we render ConfigMap from config dict.
This allows users to paste existing sc yaml configurations to values.yaml.
This approach requires no translation and is forward compatible.

This also fixes user to username rename.

On top of that I piggy-backed GOMEMLIMIT setting.