### PR TITLE
charts/sauce-connect: ensure SC HA mode

### DIFF
--- a/charts/sauce-connect/README.md
+++ b/charts/sauce-connect/README.md
@@ -24,7 +24,7 @@ For more information about the configuration options, see the [sc run command re
 
 ```bash
 helm repo add saucelabs https://opensource.saucelabs.com/helm-charts
-helm install sauce-connect  saucelabs/sauce-connect --values /path/to/values.yaml --set sc.tunnelName=your-pool-name --set tunnelPoolSize=1
+helm install sauce-connect  saucelabs/sauce-connect --values /path/to/values.yaml --set config.tunnel-name=your-pool-name --set tunnelPoolSize=2
   ```
 
 ## Application logs
@@ -46,3 +46,4 @@ The output should look like this:
 ## Pod restart
 
 The `terminationGracePeriodSeconds` is set to 600 seconds to allow sufficient time for jobs using the Sauce Connect Proxy to finish.
+It is recommended to adjust this value according to your tests typical duration.

--- a/charts/sauce-connect/templates/deployment.yaml
+++ b/charts/sauce-connect/templates/deployment.yaml
@@ -38,6 +38,13 @@ spec:
               value: /etc/config/sauce-connect.yaml
             - name: SAUCE_API_ADDRESS
               value: :{{ .Values.api.port }}
+            {{- if .Values.config.tunnel_pool }}
+            - name: SAUCE_TUNNEL_POOL
+              value: "true"
+            {{- else if gt (int .Values.tunnelPoolSize) 1 }}
+            - name: SAUCE_TUNNEL_POOL
+              value: "true"
+            {{- end }}
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:

--- a/charts/sauce-connect/tests/deployment_test.yaml
+++ b/charts/sauce-connect/tests/deployment_test.yaml
@@ -7,7 +7,7 @@ chart:
   version: 0.1.0+test
   appVersion: 1.0.0
 tests:
-  - it: should pass all kinds of assertion
+  - it: should pass all assertions
     template: templates/deployment.yaml
     documentIndex: 0
     asserts: # (3)
@@ -34,3 +34,8 @@ tests:
           of: Deployment
       - isAPIVersion:
           of: apps/v1
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "sauce-connect")].env
+          content:
+            value: "true"
+            name: SAUCE_TUNNEL_POOL

--- a/charts/sauce-connect/tests/values/test.yaml
+++ b/charts/sauce-connect/tests/values/test.yaml
@@ -2,3 +2,4 @@
 image:
   repository: saucelabs/sauce-connect
   tag: "5.0"
+tunnelPoolSize: 2

--- a/charts/sauce-connect/values.yaml
+++ b/charts/sauce-connect/values.yaml
@@ -61,7 +61,7 @@ config:
   # tunnel-name must be defined
   tunnel-name: "sc-k8s-tunnel"
 
-# See https://docs.saucelabs.com/secure-connections/sauce-connect/proxy-tunnels/#configuring-status-server
+# See https://docs.saucelabs.com/secure-connections/sauce-connect-5/operation/api-server/
 api:
   liveness: /healthz
   readiness: /readyz

--- a/charts/sauce-connect/values.yaml
+++ b/charts/sauce-connect/values.yaml
@@ -60,7 +60,6 @@ config:
   access-key: ""
   # tunnel-name must be defined
   tunnel-name: "sc-k8s-tunnel"
-  tunnel-pool: "true"
 
 # See https://docs.saucelabs.com/secure-connections/sauce-connect/proxy-tunnels/#configuring-status-server
 api:


### PR DESCRIPTION
# One-line summary

If tunnelPoolSize > 1, `sc run` must run in HA mode.

## Description

The prev chart version always started SC in HA mode (ie the config contained `tunnel_pool: true` regardless of whether there was just one client pod replica or more.  With this MR:

- if `config.tunnel-pool` is set, start SC in HA mode
   - `SAUCE_TUNNEL_POOL` is also set, but that doesn't change the behaviour
- else if `tunnelPoolSize` is greater than 1, start SC in HA mode
- else if `tunnelPoolSize` is 1, start sc without HA mode

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Configuration change
- Refactor/improvements
- Documentation / non-code

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Deploy this chart in my local cluster with `tunnelPoolSize=1` to ensure that it's templated and HA is off
  - [x] Deploy this chart in my local cluster with `tunnelPoolSize=2` to ensure that it's templated and HA is on
  - [x] Deploy this chart in my local cluster with `tunnelPoolSize=1` and `config.tunnel-pool=true` to ensure that it's templated and HA is on

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [x] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
