### PR TITLE
Add a Secret instead of using config

### DIFF
--- a/charts/sauce-connect/README.md
+++ b/charts/sauce-connect/README.md
@@ -13,8 +13,6 @@ To use this chart:
 ```yaml
 config:
   region: us-west
-  username: johndoe
-  access-key: "xxx-xxx-xxx"
   tunnel-name: "my-k8s-tunnel"
 ```
 
@@ -24,7 +22,12 @@ For more information about the configuration options, see the [sc run command re
 
 ```bash
 helm repo add saucelabs https://opensource.saucelabs.com/helm-charts
-helm install sauce-connect  saucelabs/sauce-connect --values /path/to/values.yaml --set config.tunnel-name=your-pool-name --set tunnelPoolSize=2
+helm install sauce-connect  saucelabs/sauce-connect \
+    --values /path/to/values.yaml \
+    --set config.tunnel-name=your-pool-name \
+    --set tunnelPoolSize=2 \
+    --set auth.username=user \
+    --set auth.access-key=key
   ```
 
 ## Application logs

--- a/charts/sauce-connect/templates/deployment.yaml
+++ b/charts/sauce-connect/templates/deployment.yaml
@@ -38,6 +38,16 @@ spec:
               value: /etc/config/sauce-connect.yaml
             - name: SAUCE_API_ADDRESS
               value: :{{ .Values.api.port }}
+            - name: "SAUCE_USERNAME"
+              valueFrom:
+                secretKeyRef:
+                  key:  sauce_username
+                  name: {{ .Chart.Name }}-auth
+            - name: "SAUCE_ACCESS_KEY"
+              valueFrom:
+                secretKeyRef:
+                  key:  sauce_access_key
+                  name: {{ .Chart.Name }}-auth
             {{- if .Values.config.tunnel_pool }}
             - name: SAUCE_TUNNEL_POOL
               value: "true"

--- a/charts/sauce-connect/templates/secret.yaml
+++ b/charts/sauce-connect/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Chart.Name }}-auth
+data:
+  sauce_username: {{ .Values.auth.username | b64enc }}
+  sauce_access_key: {{ .Values.auth.access-key | b64enc }}

--- a/charts/sauce-connect/values.yaml
+++ b/charts/sauce-connect/values.yaml
@@ -3,6 +3,11 @@
 # tunnelPoolSize may be increased for Sauce Connect Proxy Pool setup
 tunnelPoolSize: 1
 
+# User Credentials must be set
+auth:
+  username: ""
+  access-key: ""
+
 image:
   repository: saucelabs/sauce-connect
   pullPolicy: IfNotPresent
@@ -54,10 +59,6 @@ affinity: {}
 # See https://docs.saucelabs.com/dev/cli/sauce-connect-5/run for more options
 config:
   region: "us-west"
-  # username must be defined
-  username: ""
-  # accessKey must be defined
-  access-key: ""
   # tunnel-name must be defined
   tunnel-name: "sc-k8s-tunnel"
 


### PR DESCRIPTION
Use a Secret for user credentials instead of in the ConfigMap.

This will allow the data to be encrypted at rest, if the K8s cluster is set up for it.