### PR TITLE
Adding volumes with helm chart. Fixes #18

### DIFF
--- a/charts/sauce-connect/templates/deployment.yaml
+++ b/charts/sauce-connect/templates/deployment.yaml
@@ -53,6 +53,18 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
+          {{- range .Values.query.extraSecretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
+          {{- range .Values.query.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
           ports:
             - name: api
               containerPort: {{ .Values.api.port }}
@@ -76,6 +88,16 @@ spec:
         - name: config-volume
           configMap:
             name: {{ include "sauce-connect.fullname" . }}
+      {{- range .Values.query.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+      {{- end }}
+      {{- range .Values.query.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/sauce-connect/templates/deployment.yaml
+++ b/charts/sauce-connect/templates/deployment.yaml
@@ -54,16 +54,16 @@ spec:
             - name: config-volume
               mountPath: /etc/config
           {{- range .Values.query.extraSecretMounts }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
-              subPath: {{ .subPath }}
-              readOnly: {{ .readOnly }}
+            - name: {{ $.Values.query.extraSecretMounts.name }}
+              mountPath: {{ $.Values.query.extraSecretMounts.mountPath }}
+              subPath: {{ $.Values.query.extraSecretMounts.subPath }}
+              readOnly: {{ $.Values.query.extraSecretMounts.readOnly }}
           {{- end }}
           {{- range .Values.query.extraConfigmapMounts }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
-              subPath: {{ .subPath }}
-              readOnly: {{ .readOnly }}
+            - name: {{ $.Values.query.extraConfigmapMounts.name }}
+              mountPath: {{ $.Values.query.extraConfigmapMounts.mountPath }}
+              subPath: {{ $.Values.query.extraConfigmapMounts.subPath }}
+              readOnly: {{ $.Values.query.extraConfigmapMounts.readOnly }}
           {{- end }}
           ports:
             - name: api
@@ -89,14 +89,14 @@ spec:
           configMap:
             name: {{ include "sauce-connect.fullname" . }}
       {{- range .Values.query.extraConfigmapMounts }}
-        - name: {{ .name }}
+        - name: {{ $.Values.query.extraConfigmapMounts.name }}
           configMap:
-            name: {{ .configMap }}
+            name: {{ $.Values.query.extraConfigmapMounts.configMap }}
       {{- end }}
       {{- range .Values.query.extraSecretMounts }}
-        - name: {{ .name }}
+        - name: {{ $.Values.query.extraSecretMounts.name }}
           secret:
-            secretName: {{ .secretName }}
+            secretName: {{ $.Values.query.extraSecretMounts.secretName }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}

--- a/charts/sauce-connect/values.yaml
+++ b/charts/sauce-connect/values.yaml
@@ -26,6 +26,22 @@ serviceAccount:
 podAnnotations:
   appGroup: sauceConnect
 
+extraSecretMounts: {}
+# extraSecretMounts:
+#   name: example-cert
+#   mountPath: /etc/ssl/certs/example-cert.pem
+#   subPath: example-cert.pem # this prevents overwriting the full directory
+#   secretName: example-cert-secret
+#   readOnly: true
+
+extraConfigmapMounts: {}
+# extraConfigmapMounts:
+#   name: example-cert
+#   mountPath: /etc/ssl/certs/example-cert.pem
+#   subPath: example-cert.pem # this prevents overwriting the full directory
+#   configMap: example-cert-configmap
+#   readOnly: true
+
 podSecurityContext: {}
 securityContext: {}
 


### PR DESCRIPTION
# One-line summary

> Issue : #1234 (only if appropriate)

## Description
Adding the ability to specify additional secrets or config maps as volumes and mounts is present, along with preset volume mounts, within the Helm chart.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Refactor/improvements

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Created Volume Block in deployment.yaml for configMaps and Secrets
  - [x] Created VolumeMount Block in deployment.yaml for configMaps and Secrets
  - [x] Created examples for each in values.yaml

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Test Functionality in adding a configmap and secret. Verify secret and configmap are mounted in correct location, are not overwriting existing files at that path, and are visible from pod.
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
None
